### PR TITLE
Update io.github.HMCL_dev.HMCL.yml

### DIFF
--- a/io.github.HMCL_dev.HMCL.yml
+++ b/io.github.HMCL_dev.HMCL.yml
@@ -20,8 +20,6 @@ finish-args:
   # Java installations
   - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
   - --env=JAVA_HOME=/app/jre
-  # Disable HMCL's offline auth to comply with flathub's policy.
-  - --env=HMCL_JAVA_OPTS=-XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=15 -Dhmcl.offline.auth.restricted=true
 
 modules:
   - name: openjdk


### PR DESCRIPTION
我个人觉得这个分支的没什么问题了，就只有这个 HMCL_JAVA_OPTS 不要自定义，这个环境变量仅在调试时使用，应当有程序自行决定

到时候再加个 dev 分支和 [时更新版本](https://github.com/HMCL-dev/HMCL/actions/workflows/gradle.yml) 的更新就完美了